### PR TITLE
add all() and findById() on FeatureRepository

### DIFF
--- a/src/Domain/Repository/FeatureRepositoryInterface.php
+++ b/src/Domain/Repository/FeatureRepositoryInterface.php
@@ -18,4 +18,8 @@ interface FeatureRepositoryInterface
     public function disableFor($featureName, FeaturableInterface $featurable);
 
     public function isEnabledFor($featureName, FeaturableInterface $featurable);
+
+    public function all();
+
+    public function findById(int $id);
 }

--- a/src/Repository/EloquentFeatureRepository.php
+++ b/src/Repository/EloquentFeatureRepository.php
@@ -94,4 +94,14 @@ class EloquentFeatureRepository implements FeatureRepositoryInterface
 
         return ($model->is_enabled) ? true : $featurable->hasFeature($featureName);
     }
+
+    public function all()
+    {
+        return Model::all();
+    }
+
+    public function findById(int $id)
+    {
+        return Model::find($id);
+    }
 }

--- a/tests/Unit/Domain/FeatureManagerTest.php
+++ b/tests/Unit/Domain/FeatureManagerTest.php
@@ -22,7 +22,7 @@ class FeatureManagerTest extends TestCase
         parent::setUp();
 
         $this->repositoryMock = $this->getMockBuilder(FeatureRepositoryInterface::class)
-            ->setMethods(['save', 'remove', 'findByName', 'enableFor', 'disableFor', 'isEnabledFor'])
+            ->setMethods(['save', 'remove', 'findByName', 'enableFor', 'disableFor', 'isEnabledFor', 'all', 'findById'])
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add interface and implementation `all()` and `findById()` on `FeatureRepository` for admin dashboard purpose

## Motivation and context

Why is this change required? What problem does it solve?

If it fixes an open issue, please link to the issue here (if you write `fixes #num`
or `closes #num`, the issue will be automatically closed when the pull is accepted.)

I want to create admin dashboard for this toggle feature. I need to be able to get all the `features` and `findById` therefore I create this MR.
## How has this been tested?

Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

OTW testing
## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [ ] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ ] My pull request addresses exactly one patch/feature.
- [ ] I have created a branch for this patch/feature.
- [ ] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
